### PR TITLE
Give correct data in prob_sigma columns to show the upper and lower CI

### DIFF
--- a/src/PredictiveDensityOutput.cpp
+++ b/src/PredictiveDensityOutput.cpp
@@ -50,7 +50,8 @@ std::vector<std::string> PredictiveDensityOutput::get_output_lines() {
     ci_line += "resolution:" + to_string(_resolution) + ", ";
     ci_line += "prob_sigma:[";
     for (int i = 0; i < _ci_lower.size(); i++) {
-        ci_line += "[" + to_string(_ci_upper[i]) + "," + to_string(_ci_lower[i]) + "]";
+        ci_line += "[" + to_string((_ci_upper[i] + _ci_lower[i]) / 2.);
+        ci_line += "," + to_string((_ci_upper[i] - _ci_lower[i]) / 2.) + "]";
         if (i != _ci_lower.size() - 1) ci_line += ",";
     }
     ci_line += "]};\n";

--- a/src/WalkerDPMM.cpp
+++ b/src/WalkerDPMM.cpp
@@ -125,7 +125,8 @@ void WalkerDPMM::interpolate_calibration_curve() {
    int n = (int) calcurve.cal_age.size();
     std::vector<int> perm(n);
     std::vector<double> sorted_cal_age(calcurve.cal_age.begin(), calcurve.cal_age.end());
-    int k_start = 1.; // Start age for interpolated calendar age
+    int k_start = 1.; // TODO : allow different start ages
+    // Start age for interpolated calendar age
 
     yearwise_calcurve.cal_age.resize(max_year_bp);
     yearwise_calcurve.c14_age.resize(max_year_bp);
@@ -392,6 +393,7 @@ double WalkerDPMM::cal_age_log_likelihood(
     int yr;
 
     yr = (int) cal_age - 1;
+    // TODO: Change this
     if ((yr < 0) || (yr >= max_year_bp)) {  // out of range
         return -std::numeric_limits<double>::infinity();
     }


### PR DESCRIPTION
Note that for the KDE models the columns should show the mean and standard deviation. Here we output (cl+cu)/2 and (cl-cu)/2 to make the plot look correct (where cl and cu are the lower and upper confidence intervals).