### PR TITLE
Simplify ranges

### DIFF
--- a/data/kerr_c14age.oxcal
+++ b/data/kerr_c14age.oxcal
@@ -1,12 +1,12 @@
 Options()
 {
-    Resolution=10;
+    Resolution=5;
     Curve="intcal20.14c";
     UseF14C=TRUE;
     Floruit=FALSE;
     SD1=TRUE;
-    SD2=FALSE;
-    SD3=TRUE;
+    SD2=TRUE;
+    SD3=FALSE;
     kIterations=100;
 };
 Plot()

--- a/src/DensityOutput.cpp
+++ b/src/DensityOutput.cpp
@@ -82,6 +82,13 @@ void DensityOutput::_set_probability(const std::vector<double>& probability) {
     // Scale so that the maximum value of the density is 1.
     for (double & prob : _probability) prob /= _prob_max;
     _prob_norm = _prob_max / (prob_total * _resolution);
+
+    _smoothed_probability.resize(_probability.size());
+    int last = (int) _probability.size() - 1;
+    _smoothed_probability[0] = (2. * _probability[0] + _probability[1]) / 3.;
+    for (int i = 1; i < last; i++)
+        _smoothed_probability[i] = (_probability[i - 1] + _probability[i] + _probability[i + 1]) / 3.;
+    _smoothed_probability[last - 1] = (_probability[last - 1] + 2. * _probability[last]) / 3.;
 }
 
 

--- a/src/DensityOutput.h
+++ b/src/DensityOutput.h
@@ -30,6 +30,7 @@ public:
 class DensityOutput {
 protected:
     std::vector<double> _probability;
+    std::vector<double> _smoothed_probability;
     std::string _output_var;
     std::string _output_prefix;
     int _index;

--- a/src/PosteriorDensityOutput.cpp
+++ b/src/PosteriorDensityOutput.cpp
@@ -112,6 +112,22 @@ double PosteriorDensityOutput::find_probability_and_ranges_for_cut_off(
     return total_probability;
 }
 
+// Merges any ranges which are separated by a distance less than the current resolution
+std::vector<std::vector<double>> PosteriorDensityOutput::simplify_ranges(std::vector<std::vector<double>> &ranges) {
+    std::vector<std::vector<double>> new_ranges;
+
+    new_ranges.push_back(ranges[0]);
+    for (int i = 1; i < ranges.size(); i++) {
+        if (ranges[i][0] - ranges[i - 1][1] >= _resolution) {
+            new_ranges.push_back(ranges[i]);
+        } else {
+            new_ranges[new_ranges.size() - 1][1] = ranges[i][1];
+            new_ranges[new_ranges.size() - 1][2] += ranges[i][2];
+        }
+    }
+    return new_ranges;
+}
+
 // Finds the calendar age ranges between which the probability matches the provided probability
 // where the points with the highest probability are chosen first. Returns the result as a
 // vector of vectors, where each entry contains
@@ -138,6 +154,7 @@ std::vector<std::vector<double>> PosteriorDensityOutput::get_ranges_by_intercept
             a = p;
         }
     }
+    ranges = simplify_ranges(ranges);
     return ranges;
 }
 

--- a/src/PosteriorDensityOutput.h
+++ b/src/PosteriorDensityOutput.h
@@ -22,6 +22,7 @@ public:
 
 private:
     double find_probability_and_ranges_for_cut_off(double cut_off, std::vector<std::vector<double>>& ranges);
+    std::vector<std::vector<double>> simplify_ranges(std::vector<std::vector<double>>& ranges);
     std::vector<std::vector<double>> get_ranges_by_intercepts(double probability);
     std::vector<std::vector<double>> get_ranges(double probability);
 };


### PR DESCRIPTION
Use a moving average of 3 points to calculate a smoothed posterior density, which is used only for calculating the HPD (the unsmoothed posterior density is what is written to the output).

Also once the HPD is calculated, if there are any ranges that are separated by less than the resolution, merge them. Note this will give results that aren't 100% accurate - I'll check with Tim and Christopher if this is ok.